### PR TITLE
test: commands 테스트 기능 추가

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globalSetup: './testing/setup.ts',
 };

--- a/sources/commands/ListCommand.test.ts
+++ b/sources/commands/ListCommand.test.ts
@@ -1,15 +1,5 @@
-import * as execa from 'execa';
 import { CommitResult } from 'simple-git/promise';
 import { initializeTestRepository, Package, Repository } from '../../testing/repository';
-
-/**
- * yarn build로 timeout되는 것을 방지
- */
-jest.setTimeout(20000);
-
-beforeAll(async () => {
-  await execa('yarn', ['build']);
-});
 
 describe('ListCommand', () => {
   let repository: Repository;
@@ -30,7 +20,7 @@ describe('ListCommand', () => {
   });
 
   describe('yarn workspaces since list <from>', () => {
-    it('모든 package에 변경사항이 없으면 아무 것도 출력하지 않는다.', async () => {
+    it('모든 package에 변경사항이 없으면 아무 것도 출력하지 않는다', async () => {
       await repository.commitAll('Empty commit');
 
       const result = await repository.exec('yarn', [

--- a/sources/commands/ListCommand.test.ts
+++ b/sources/commands/ListCommand.test.ts
@@ -1,108 +1,131 @@
-import { CommitResult } from 'simple-git/promise';
 import { initializeTestRepository, Package, Repository } from '../../testing/repository';
 
+async function setup() {
+  const repository = await initializeTestRepository();
+  const packages = await Promise.all([
+    repository.addPackage('package1'),
+    repository.addPackage('package2'),
+    repository.addPackage('package3'),
+  ]);
+  const initialCommit = await repository.commitAll('Add packages');
+  return {
+    repository,
+    packages,
+    initialCommit,
+  };
+}
+
 describe('ListCommand', () => {
-  let repository: Repository;
-  let packages: [Package, Package, Package];
-  let initialCommit: CommitResult;
-
-  beforeEach(async () => {
-    repository = await initializeTestRepository();
-    packages = await Promise.all([
-      repository.addPackage('package1'),
-      repository.addPackage('package2'),
-      repository.addPackage('package3'),
-    ]);
-    initialCommit = await repository.commitAll('Add packages');
-  });
-  afterEach(async () => {
-    await repository.cleanup();
-  });
-
   describe('yarn workspaces since list <from>', () => {
     it('모든 package에 변경사항이 없으면 아무 것도 출력하지 않는다', async () => {
-      await repository.commitAll('Empty commit');
+      const { repository, initialCommit } = await setup();
+      try {
+        await repository.commitAll('Empty commit');
 
-      const result = await repository.exec('yarn', [
-        'workspaces',
-        'since',
-        'list',
-        initialCommit.commit,
-      ]);
+        const result = await repository.exec('yarn', [
+          'workspaces',
+          'since',
+          'list',
+          initialCommit.commit,
+        ]);
 
-      expect(result.stdout).toBe('');
+        expect(result.stdout).toBe('');
+      } finally {
+        await repository.cleanup();
+      }
     });
     it('변경된 package가 있다면 해당 package들을 출력한다', async () => {
-      const [package1, package2] = packages;
+      const {
+        repository,
+        initialCommit,
+        packages: [package1, package2],
+      } = await setup();
 
-      await Promise.all([
-        package1.addFile('package1.ts', '"I am updated"'),
-        package2.addFile('package2.ts', '"I am updated"'),
-      ]);
+      try {
+        await Promise.all([
+          package1.addFile('package1.ts', '"I am updated"'),
+          package2.addFile('package2.ts', '"I am updated"'),
+        ]);
 
-      await repository.commitAll('Update package1 and package2');
+        await repository.commitAll('Update package1 and package2');
 
-      const result = await repository.exec('yarn', [
-        'workspaces',
-        'since',
-        'list',
-        initialCommit.commit,
-      ]);
+        const result = await repository.exec('yarn', [
+          'workspaces',
+          'since',
+          'list',
+          initialCommit.commit,
+        ]);
 
-      const updatedPackages = result.stdout.split('\n');
-      expect(updatedPackages).toContain('packages/package1');
-      expect(updatedPackages).toContain('packages/package2');
+        const updatedPackages = result.stdout.split('\n');
+        expect(updatedPackages).toContain('packages/package1');
+        expect(updatedPackages).toContain('packages/package2');
+      } finally {
+        await repository.cleanup();
+      }
     });
   });
 
   describe('yarn workspaces since list <from> <to>', () => {
-    let firstCommit: CommitResult;
-    let secondCommit: CommitResult;
-
-    beforeEach(async () => {
-      const [package1, package2, package3] = packages;
+    async function setupTestCommits() {
+      const setupResult = await setup();
+      const {
+        repository,
+        packages: [package1, package2, package3],
+      } = setupResult;
 
       await Promise.all([
         package1.addFile('package1.ts', '"I am updated"'),
         package2.addFile('package2.ts', '"I am updated"'),
       ]);
 
-      firstCommit = await repository.commitAll('Update package1 and package2');
+      const firstCommit = await repository.commitAll('Update package1 and package2');
 
       await Promise.all([
         package2.addFile('package2.tsx', '"I am updated"'),
         package3.addFile('package3.tsx', '"I am updated"'),
       ]);
 
-      secondCommit = await repository.commitAll('Update package2 and package3');
-    });
+      const secondCommit = await repository.commitAll('Update package2 and package3');
+
+      return { ...setupResult, firstCommit, secondCommit };
+    }
 
     it('<to>까지 변경된 package들을 출력한다 1', async () => {
-      const result = await repository.exec('yarn', [
-        'workspaces',
-        'since',
-        'list',
-        initialCommit.commit,
-        firstCommit.commit,
-      ]);
+      const { repository, initialCommit, firstCommit } = await setupTestCommits();
+      try {
+        const result = await repository.exec('yarn', [
+          'workspaces',
+          'since',
+          'list',
+          initialCommit.commit,
+          firstCommit.commit,
+        ]);
 
-      const updatedPackages = result.stdout.split('\n');
-      expect(updatedPackages).toContain('packages/package1');
-      expect(updatedPackages).toContain('packages/package2');
+        const updatedPackages = result.stdout.split('\n');
+        expect(updatedPackages).toContain('packages/package1');
+        expect(updatedPackages).toContain('packages/package2');
+      } finally {
+        await repository.cleanup();
+      }
     });
     it('<to>까지 변경된 package들을 출력한다 2', async () => {
-      const result = await repository.exec('yarn', [
-        'workspaces',
-        'since',
-        'list',
-        initialCommit.commit,
-        secondCommit.commit,
-      ]);
+      const { repository, initialCommit, secondCommit } = await setupTestCommits();
+      try {
+        const result = await repository.exec('yarn', [
+          'workspaces',
+          'since',
+          'list',
+          initialCommit.commit,
+          secondCommit.commit,
+        ]);
 
-      const updatedPackages = result.stdout.split('\n');
-      expect(updatedPackages).toContain('packages/package1');
-      expect(updatedPackages).toContain('packages/package2');
-      expect(updatedPackages).toContain('packages/package3');
+        const updatedPackages = result.stdout.split('\n');
+        expect(updatedPackages).toContain('packages/package1');
+        expect(updatedPackages).toContain('packages/package2');
+        expect(updatedPackages).toContain('packages/package3');
+      } finally {
+        await repository.cleanup();
+      }
     });
   });
 });

--- a/sources/commands/ListCommand.test.ts
+++ b/sources/commands/ListCommand.test.ts
@@ -1,0 +1,37 @@
+import * as execa from 'execa';
+import { initializeTestRepository } from '../../testing/repository';
+
+jest.setTimeout(20000);
+
+describe('ListCommand는', () => {
+  beforeAll(async () => {
+    await execa('yarn', ['build']);
+  });
+  it('모든 workspace에 변경사항이 없으면 아무 것도 출력하지 않는다.', async () => {
+    const repository = await initializeTestRepository();
+    try {
+      const [package1, package2, package3] = await Promise.all([
+        repository.addPackage('package1'),
+        repository.addPackage('package2'),
+        repository.addPackage('package3'),
+      ]);
+
+      const beforeCommit = await repository.commitAll('Add packages');
+      const beforeCommitSha = beforeCommit.commit;
+
+      const afterCommit = await repository.commitAll('Empty commit');
+      const afterCommitSha = afterCommit.commit;
+
+      const result = await repository.exec('yarn', [
+        'workspaces',
+        'since',
+        'list',
+        beforeCommitSha,
+      ]);
+
+      expect(result.stdout).toBe('');
+    } finally {
+      repository.cleanup();
+    }
+  });
+});

--- a/sources/commands/ListCommand.test.ts
+++ b/sources/commands/ListCommand.test.ts
@@ -1,37 +1,62 @@
 import * as execa from 'execa';
-import { initializeTestRepository } from '../../testing/repository';
+import { CommitResult } from 'simple-git/promise';
+import { initializeTestRepository, Package, Repository } from '../../testing/repository';
 
+/**
+ * yarn build로 timeout되는 것을 방지
+ */
 jest.setTimeout(20000);
 
-describe('ListCommand는', () => {
+describe('ListCommand', () => {
+  let repository: Repository;
+  let packages: [Package, Package, Package];
+  let initialCommit: CommitResult;
   beforeAll(async () => {
     await execa('yarn', ['build']);
   });
-  it('모든 workspace에 변경사항이 없으면 아무 것도 출력하지 않는다.', async () => {
-    const repository = await initializeTestRepository();
-    try {
-      const [package1, package2, package3] = await Promise.all([
-        repository.addPackage('package1'),
-        repository.addPackage('package2'),
-        repository.addPackage('package3'),
-      ]);
-
-      const beforeCommit = await repository.commitAll('Add packages');
-      const beforeCommitSha = beforeCommit.commit;
-
-      const afterCommit = await repository.commitAll('Empty commit');
-      const afterCommitSha = afterCommit.commit;
+  beforeEach(async () => {
+    repository = await initializeTestRepository();
+    packages = await Promise.all([
+      repository.addPackage('package1'),
+      repository.addPackage('package2'),
+      repository.addPackage('package3'),
+    ]);
+    initialCommit = await repository.commitAll('Add packages');
+  });
+  afterEach(async () => {
+    repository.cleanup();
+  });
+  describe('yarn workspaces since list <from>', () => {
+    it('모든 workspace에 변경사항이 없으면 아무 것도 출력하지 않는다.', async () => {
+      await repository.commitAll('Empty commit');
 
       const result = await repository.exec('yarn', [
         'workspaces',
         'since',
         'list',
-        beforeCommitSha,
+        initialCommit.commit,
       ]);
 
       expect(result.stdout).toBe('');
-    } finally {
-      repository.cleanup();
-    }
+    });
+    it('변경된 workspace가 있다면 해당 workspace들을 순서대로 출력한다', async () => {
+      const [package1, package2] = packages;
+
+      await Promise.all([
+        package1.addFile('package1.ts', '"I am updated"'),
+        package2.addFile('package2.ts', '"I am updated"'),
+      ]);
+
+      await repository.commitAll('Update package1 and package2');
+
+      const result = await repository.exec('yarn', [
+        'workspaces',
+        'since',
+        'list',
+        initialCommit.commit,
+      ]);
+
+      expect(result.stdout).toBe('packages/package1\npackages/package2');
+    });
   });
 });

--- a/sources/getUpdatedWorkspaces/getDependentWorkspace.ts
+++ b/sources/getUpdatedWorkspaces/getDependentWorkspace.ts
@@ -29,7 +29,7 @@ export default function getDependentWorkspace({
     if (directDependents.length === 0) {
       return [];
     }
-  
+
     return [
       ...directDependents,
       ...directDependents.flatMap(dependent => {
@@ -41,5 +41,5 @@ export default function getDependentWorkspace({
     ];
   }
 
-  return _getDependentWorkspaces({ allWorkspaces, dependency })
+  return _getDependentWorkspaces({ allWorkspaces, dependency });
 }

--- a/sources/getUpdatedWorkspaces/getUpdatedWorkspaces.test.ts
+++ b/sources/getUpdatedWorkspaces/getUpdatedWorkspaces.test.ts
@@ -1,8 +1,8 @@
 import { initializeTestRepository } from '../../testing/repository';
 import getUpdatedWorkspaces from './getUpdatedWorkspaces';
 
-describe('getUpdatedWorkspaces는', () => {
-  it('Workspace 내부의 업데이트된 패키지 리스트를 반환한다.', async () => {
+describe('getUpdatedWorkspaces', () => {
+  it('Workspace 내부의 업데이트된 패키지 리스트를 반환한다', async () => {
     const repository = await initializeTestRepository();
 
     try {
@@ -35,9 +35,9 @@ describe('getUpdatedWorkspaces는', () => {
     }
   });
 
-  it('한글을 포함하는 경로의 파일이 업데이트된 경우에도 정상적으로 동작한다.', async () => {
+  it('한글을 포함하는 경로의 파일이 업데이트된 경우에도 정상적으로 동작한다', async () => {
     const repository = await initializeTestRepository();
-    
+
     try {
       const [package1, package2] = await Promise.all([
         repository.addPackage('package1'),

--- a/sources/getUpdatedWorkspaces/getUpdatedWorkspaces.ts
+++ b/sources/getUpdatedWorkspaces/getUpdatedWorkspaces.ts
@@ -17,7 +17,9 @@ export default async function getUpdatedWorkspaces({
   ignore?: string;
   workspaceDir?: string;
 }) {
-  const matchedWorkspaceGlobs = PackageJson(workspaceDir).workspaces.filter(v => !minimatch(v, ignore));
+  const matchedWorkspaceGlobs = PackageJson(workspaceDir).workspaces.filter(
+    v => !minimatch(v, ignore),
+  );
 
   const allWorkspaces = await getWorkspacesList({ cwd: workspaceDir });
   const allLocations = allWorkspaces.map(v => v.location);

--- a/sources/index.ts
+++ b/sources/index.ts
@@ -4,7 +4,7 @@ import RunCommand from './commands/RunCommand';
 import VersionCommand from './commands/VersionCommand';
 
 const plugin: Plugin = {
-  commands: [ListCommand, RunCommand, VersionCommand]
+  commands: [ListCommand, RunCommand, VersionCommand],
 };
 
 export default plugin;

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -23,10 +23,28 @@ export const YARN_RC_WORKSPACE_TOOLS_PATH = path.join(
 );
 
 /**
- * 실제 Yarn Workspace Since Plugin의 경로
+ * 실제 Yarn Workspace Plugin의 경로
  */
 export const YARN_WORKSPACE_TOOLS_RELEASE_FILE_PATH = path.resolve(
   __dirname,
   '..',
   YARN_RC_WORKSPACE_TOOLS_PATH,
+);
+
+/**
+ * Yarn Workspace Since 번들 위치
+ */
+export const YARN_RC_WORKSPACE_SINCE_BUNDLE_PATH = path.join(
+  'bundles',
+  '@yarnpkg',
+  'plugin-workspace-since.js',
+);
+
+/**
+ * Yarn Workspace Since 경로
+ */
+export const YARN_WORKSPACE_SINCE_BUNDLE_FILE_PATH = path.resolve(
+  __dirname,
+  '..',
+  YARN_RC_WORKSPACE_SINCE_BUNDLE_PATH,
 );

--- a/testing/repository.ts
+++ b/testing/repository.ts
@@ -35,6 +35,7 @@ export async function initializeTestRepository() {
     cleanup: async () => {
       xfs.detachTemp(repoDir);
     },
+    exec: (cmd: string, args: string[]) => execa(cmd, args, { cwd: repoDir })
   };
 
   async function commitAll(msg: string) {

--- a/testing/repository.ts
+++ b/testing/repository.ts
@@ -12,7 +12,17 @@ import {
 } from './constants';
 import { Sema } from 'async-sema';
 
-export async function initializeTestRepository() {
+export interface Repository {
+  git: gitP.SimpleGit;
+  dir: string;
+  addPackage: (name: string) => Promise<Package>;
+  install: () => Promise<void>;
+  commitAll: (msg: string) => Promise<gitP.CommitResult>;
+  cleanup: () => Promise<void>;
+  exec: (cmd: string, args: string[]) => execa.ExecaChildProcess<string>;
+}
+
+export async function initializeTestRepository(): Promise<Repository> {
   const repoDir = await xfs.mktempPromise();
 
   const git = await gitP(repoDir);
@@ -131,10 +141,20 @@ async function setupYarnBinary(repoDir: string) {
   ]);
 }
 
+export interface Package {
+  name: string;
+  path: string;
+  addFile: (filePath: string, content: string | Buffer) => Promise<void>;
+}
+
 /**
  * `repoDir`로 주어진 Yarn Berry Workspace에 `name` 이름을 가지는 테스트용 패키지를 추가합니다.
  */
-async function initializeWorkspacePackage(repoDir: string, name: string, packagePath: string) {
+async function initializeWorkspacePackage(
+  repoDir: string,
+  name: string,
+  packagePath: string,
+): Promise<Package> {
   const targetPath = npath.toPortablePath(path.join(repoDir, packagePath, 'package.json'));
   const content = JSON.stringify({
     name,

--- a/testing/setup.ts
+++ b/testing/setup.ts
@@ -1,0 +1,5 @@
+import * as execa from 'execa';
+
+export default async () => {
+  await execa('yarn', ['build']);
+};


### PR DESCRIPTION
- commands를 E2E 테스트할 수 있는 환경을 구축합니다.
  - setup에서 since 번들링
  - 테스트 디렉토리에 since 번들 복사 및 yarnrc에 입력
  - repository에 exec 함수 추가
- 테스트 문구를 일괄적으로 워싱합니다. (온점 제거, ~는 제거 등)
- 코드 스타일을 통일합니다
  - prettierrc는 있지만 prettier가 없어서, 다음 PR에서 셋업해볼 예정입니다.
